### PR TITLE
Public storage for model

### DIFF
--- a/spacy_lefff/downloader.py
+++ b/spacy_lefff/downloader.py
@@ -23,18 +23,6 @@ class Downloader(object):
         else:
             LOGGER.info('data already set up')
 
-    @staticmethod
-    def get_filename_from_cd(cd):
-        """
-        Get filename from content-disposition
-        """
-        if not cd:
-            return None
-        fname = re.findall('filename="(.+)"', cd)
-        if len(fname) == 0:
-            return None
-        return fname[0]
-
     def _download_data(self):
         LOGGER.info('downloading data for {}...'.format(self.pkg))
         r = requests.get(self.url, stream=True)
@@ -46,8 +34,7 @@ class Downloader(object):
             LOGGER.error("Couldn't fetch model data.")
             raise Exception("Couldn't fetch model data.")
         else:
-            filename = self.get_filename_from_cd(
-                r.headers.get('content-disposition'))
+            filename = 'model.tar.gz'
             path = os.path.join(self.download_dir, filename)
             with open(path, 'wb') as f:
                 for data in r.iter_content(chunk_size=4096):

--- a/spacy_lefff/melt_tagger.py
+++ b/spacy_lefff/melt_tagger.py
@@ -57,7 +57,7 @@ MODELS_DIR = os.path.join(DATA_DIR, PACKAGE, 'models/fr')
 LEXICON_FILE = os.path.join(MODELS_DIR, 'lexicon.json')
 TAG_DICT = os.path.join(MODELS_DIR, 'tag_dict.json')
 
-URL_MODEL = 'https://github.com/sammous/spacy-lefff-model/raw/master/model.tar.gz'
+URL_MODEL = 'https://github.com/sammous/spacy-lefff-model/releases/download/v0.1.0/model.tar.gz'
 
 # extra options dict for feature selection
 feat_select_options = {

--- a/spacy_lefff/melt_tagger.py
+++ b/spacy_lefff/melt_tagger.py
@@ -57,7 +57,7 @@ MODELS_DIR = os.path.join(DATA_DIR, PACKAGE, 'models/fr')
 LEXICON_FILE = os.path.join(MODELS_DIR, 'lexicon.json')
 TAG_DICT = os.path.join(MODELS_DIR, 'tag_dict.json')
 
-URL_MODEL = 'https://www.dropbox.com/s/xjn863wq4599vur/model.tar.gz?dl=1'
+URL_MODEL = 'https://github.com/sammous/spacy-lefff-model/raw/master/model.tar.gz'
 
 # extra options dict for feature selection
 feat_select_options = {

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -14,10 +14,6 @@ from spacy_lefff.melt_tagger import URL_MODEL
 def test_url_model():
     assert requests.get(URL_MODEL).status_code == 200
 
-def test_get_filename_from_cd():
-    cd = 'attachment; filename="model.tar.gz"; filename*=UTF-8''model.tar.gz'
-    assert Downloader.get_filename_from_cd(cd) == 'model.tar.gz'
-
 def _mock_response(
         status=200,
         content="CONTENT",


### PR DESCRIPTION
For transparency, model storage was migrated to github to follow `spacy` standard.
Repository containing the released model can be found [here](https://github.com/sammous/spacy-lefff-model).