### PR TITLE
Loosened requirements on spacy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy>=3.0.0,<3.0.5
+spacy~=3.0
 tqdm>=4.11.1
 msgpack>=0.3.0,<0.6
 pluggy>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,13 @@ def setup_package():
         author='sami moustachir',
         author_email='moustachir.sami@gmail.com',
         url='https://github.com/sammous/spacy-lefff',
-        version='0.4.0',
+        version='0.4.1',
         license='MIT',
         packages=find_packages(exclude=['tests']),
         package_data={'spacy_lefff': ['data/*']},
         tests_require=['pytest', 'pytest-cov'],
         install_requires=[
-            'spacy>=3.0.0,<3.0.5'],
+            'spacy>=3.0.0,<4.0.0'],
         zip_safe=False,
         classifiers=[
             'Programming Language :: Python',


### PR DESCRIPTION
Hi !
Thanks for your nice integration, this works very well for our various use cases.
In reference to issue #36  I 'd like to propose this fix to improve compatibility with upcoming spacy versions (> 3.0).

Tests seem to pass with spacy 3.4.1, and POS still make sense on a couple of examples, so I'd say that your package still works with newer versions of Spacy. However, being no morpho-syntactic expert, feel free to double-check :) 